### PR TITLE
backends/elasticsearch: Fix agg. and flatten results by default

### DIFF
--- a/sql_mojo/backends/elasticsearch.py
+++ b/sql_mojo/backends/elasticsearch.py
@@ -75,9 +75,12 @@ class ElasticBackend:
             index, query = self.translate(data)
 
             response = self.client.search(index=index, body=query)
-            result = response.get("aggregations")
-            if result is None:
-                result = response["hits"]["hits"]
+            agg = response.get("aggregations")
+            if agg:
+                agg = agg.popitem()
+                result = [{agg[0]: agg[1]["value"]}]
+            else:
+                result = [hit["_source"] for hit in response["hits"]["hits"]]
 
         except elasticsearch.exceptions.RequestError as exc:
             result = exc.info["error"]["root_cause"][0]["reason"]


### PR DESCRIPTION
- Make the query result always flat so it is shown as a table by default
  Showing additional meta data should be optional and handled
  via CLI options or even better - a settings file.
- Also fix aggregation queries, they didn't work because the `is_flat` function
  expects a list of things but a dict was passed.